### PR TITLE
Fix for chart not showing in Firefox

### DIFF
--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -41,7 +41,7 @@ class LineChart extends Component {
 
     pathD += data.map((point, i) => {
       return "L " + this.getSvgX(point.x) + " " + this.getSvgY(point.y) + " ";
-    });
+    }).join("");
 
     return (
       <path className="linechart_path" d={pathD} style={{stroke: color}} />
@@ -54,7 +54,7 @@ class LineChart extends Component {
 
     pathD += data.map((point, i) => {
       return "L " + this.getSvgX(point.x) + " " + this.getSvgY(point.y) + " ";
-    });
+    }).join("");
 
     const x = this.getX();
     const y = this.getY();


### PR DESCRIPTION
This addresses issue #3.

The problem was Firefox does not handle commas (`,`) in an SVG path. See https://stackoverflow.com/questions/12661323/svg-path-tag-does-not-work-on-firefox.

This was occuring in `makePath()` and `makeArea()` when the string `pathD` was concatenated to the array result of `data.map`.

I've added a `.join("")` onto the end of result to `.map()` to turn it back into a string.

## Before
![image](https://user-images.githubusercontent.com/13941027/34517451-01ef64e4-f073-11e7-898a-f35b9ce60239.png)

## After
![image](https://user-images.githubusercontent.com/13941027/34517476-116dcdde-f073-11e7-974e-a032fb622167.png)

## After in Chrome
![image](https://user-images.githubusercontent.com/13941027/34517638-b78a3450-f073-11e7-8c38-2421f9e7e767.png)
